### PR TITLE
[Matching API]

### DIFF
--- a/src/main/java/ssamchi/softeer/drivechat/controller/MatchController.java
+++ b/src/main/java/ssamchi/softeer/drivechat/controller/MatchController.java
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import ssamchi.softeer.drivechat.dto.common.ResponseDto;
 import ssamchi.softeer.drivechat.dto.request.ConversationRequestDto;
+import ssamchi.softeer.drivechat.dto.request.RequestMakeMatchingDto;
+import ssamchi.softeer.drivechat.dto.response.ResponseMakeMatchingDto;
+import ssamchi.softeer.drivechat.dto.response.ResponseMatchCheckDto;
 import ssamchi.softeer.drivechat.dto.response.SummaryResponseDto;
 import ssamchi.softeer.drivechat.service.MatchService;
 
@@ -26,4 +29,25 @@ public class MatchController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/register")
+    public ResponseEntity<ResponseDto<ResponseMakeMatchingDto>> makeMatching
+            (
+                    @RequestBody RequestMakeMatchingDto requestMakeMatchingDto
+            )
+    {
+        ResponseMakeMatchingDto responseMakeMatchingDto = matchService.makeMatching(requestMakeMatchingDto);
+        return ResponseEntity.ok()
+                .body(ResponseDto.of(HttpStatus.OK.value(), "match created", responseMakeMatchingDto));
+    }
+
+    @GetMapping("/driver/{driverId}")
+    public ResponseEntity<ResponseDto<ResponseMatchCheckDto>> checkMatching
+            (
+                @PathVariable Long driverId
+            )
+    {
+        ResponseMatchCheckDto responseMatchCheckDto = matchService.checkMatching(driverId);
+        return ResponseEntity.ok()
+                .body(ResponseDto.of(HttpStatus.OK.value(), "match ", responseMatchCheckDto));
+    }
 }

--- a/src/main/java/ssamchi/softeer/drivechat/dto/request/RequestMakeMatchingDto.java
+++ b/src/main/java/ssamchi/softeer/drivechat/dto/request/RequestMakeMatchingDto.java
@@ -1,0 +1,11 @@
+package ssamchi.softeer.drivechat.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RequestMakeMatchingDto {
+    private Long driverId;
+}

--- a/src/main/java/ssamchi/softeer/drivechat/dto/request/RequestMatchCheckDto.java
+++ b/src/main/java/ssamchi/softeer/drivechat/dto/request/RequestMatchCheckDto.java
@@ -1,0 +1,12 @@
+package ssamchi.softeer.drivechat.dto.request;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RequestMatchCheckDto {
+    private Long userId;
+}

--- a/src/main/java/ssamchi/softeer/drivechat/dto/response/ResponseMakeMatchingDto.java
+++ b/src/main/java/ssamchi/softeer/drivechat/dto/response/ResponseMakeMatchingDto.java
@@ -1,0 +1,17 @@
+package ssamchi.softeer.drivechat.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResponseMakeMatchingDto {
+    private Long matchId;
+
+    @Builder
+    public ResponseMakeMatchingDto(Long matchId) {
+        this.matchId = matchId;
+    }
+}

--- a/src/main/java/ssamchi/softeer/drivechat/dto/response/ResponseMatchCheckDto.java
+++ b/src/main/java/ssamchi/softeer/drivechat/dto/response/ResponseMatchCheckDto.java
@@ -1,0 +1,18 @@
+package ssamchi.softeer.drivechat.dto.response;
+
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResponseMatchCheckDto {
+    private Boolean isFound;
+
+    @Builder
+    public ResponseMatchCheckDto(Boolean isFound) {
+        this.isFound = isFound;
+    }
+}

--- a/src/main/java/ssamchi/softeer/drivechat/repository/DriverRepository.java
+++ b/src/main/java/ssamchi/softeer/drivechat/repository/DriverRepository.java
@@ -13,9 +13,4 @@ public interface DriverRepository extends JpaRepository<Driver, Long> {
     List<Driver> findDriversByFoundIsFalse();
 
     Optional<Driver> findByDriverId(Long driverId);
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE Driver d SET d.found = :found WHERE d.driverId = :driverId")
-    void updateFound(Long driverId, boolean found);
-
 }

--- a/src/main/java/ssamchi/softeer/drivechat/repository/DriverRepository.java
+++ b/src/main/java/ssamchi/softeer/drivechat/repository/DriverRepository.java
@@ -3,6 +3,8 @@ package ssamchi.softeer.drivechat.repository;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import ssamchi.softeer.drivechat.domain.Driver;
 
 public interface DriverRepository extends JpaRepository<Driver, Long> {
@@ -11,4 +13,9 @@ public interface DriverRepository extends JpaRepository<Driver, Long> {
     List<Driver> findDriversByFoundIsFalse();
 
     Optional<Driver> findByDriverId(Long driverId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Driver d SET d.found = :found WHERE d.driverId = :driverId")
+    void updateFound(Long driverId, boolean found);
+
 }

--- a/src/main/java/ssamchi/softeer/drivechat/service/MatchService.java
+++ b/src/main/java/ssamchi/softeer/drivechat/service/MatchService.java
@@ -72,7 +72,8 @@ public class MatchService {
         );
 
         // modify isFound
-        driverRepository.updateFound(driver.getDriverId(), true);
+        driver.found();
+        driverRepository.save(driver);
 
         return ResponseMakeMatchingDto.builder()
                 .matchId(newMatch.getMatchId())


### PR DESCRIPTION
## 매칭 API

1. Driver가 운전 일정을 생성함. (= 운전자 등록)
    1. Guest가 고르기 전까지 주기적으로 BE에 상태를 확인한다.`/api/match/driver/{driverId}`
2. Guest가 운전 일정들 중 하나를 골라 탑승 요청을 한다 `/api/match/register`
    1. 이 때 FE가 보내는 userId와 DriverId를 받아 DB에 해당 Match를 등록하고 Driver의 Found를 변경한다.
    2. FE에는 응답으로 matchId를 보냄.